### PR TITLE
Add gperftools 2.9.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 default: cedar-14 heroku-16 heroku-18
 
-VERSION := 2.7
+VERSION := 2.9.1
 ROOT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 
 clean:


### PR DESCRIPTION
```
This commit updates gperftools to 2.9.1. See the changelog on the GitHub
releases page for updates to tcmalloc:

https://github.com/gperftools/gperftools/releases
```